### PR TITLE
document.body.scrollTop is always 0 in Firefox.

### DIFF
--- a/src/Tipsy.js
+++ b/src/Tipsy.js
@@ -212,9 +212,11 @@ Tipsy.version = "0.5.1";
 // IE8+ equiv. of $.fn.offset
 function offset(el) {
   const rect = el.getBoundingClientRect();
+  const scrollTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
+  const scrollLeft = window.pageXOffset || document.documentElement.scrollLeft || document.body.scrollLeft || 0;
 
   return {
-    top: rect.top + document.body.scrollTop,
-    left: rect.left + document.body.scrollLeft
+    top: rect.top + scrollTop,
+    left: rect.left + scrollLeft
   };
 }


### PR DESCRIPTION
- In Firefox, `document.body.scrollTop` and `document.body.scrollLeft` returns always 0.
- See also: [javascript - document.body.scrollTop Firefox returns 0 : ONLY JS - Stack Overflow](https://stackoverflow.com/questions/28633221/document-body-scrolltop-firefox-returns-0-only-js)

## before

![before](https://user-images.githubusercontent.com/18360/28699130-c866540c-7382-11e7-9798-6d3926339550.gif)

## after

![after](https://user-images.githubusercontent.com/18360/28699136-cd2a6c4e-7382-11e7-86b1-b8cae2dd9c33.gif)
