### PR TITLE
Exclude from package source and examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "0.6.0",
   "description": "A React component that allows you to easily create simple tooltips.",
   "main": "dist/react-tipsy.js",
+  "files": [
+    "dist",
+    "CHANGES",
+    "LICENSE",
+    "README.md"
+  ],
   "scripts": {
     "build": "npm run lessc; webpack --config examples/src/webpack.config.js; webpack; NODE_ENV=production webpack -p",
     "lessc": "lessc less/tipsy.less dist/react-tipsy.css",


### PR DESCRIPTION
Explicit the list of files to package.

It doesn't change anything in the package behavior nor improve its performance, it just makes it smaller to download / smaller in the `node_modules`. More especially since `examples` take a lot of space in proportion.

```bash
$ du -hs node_modules/react-tipsy/*
4.0K	node_modules/react-tipsy/CHANGES
4.0K	node_modules/react-tipsy/LICENSE
4.0K	node_modules/react-tipsy/README.md
20K	node_modules/react-tipsy/dist
760K	node_modules/react-tipsy/examples
12K	node_modules/react-tipsy/less
4.0K	node_modules/react-tipsy/package.json
8.0K	node_modules/react-tipsy/src
4.0K	node_modules/react-tipsy/webpack.config.js
```

After this change.

```bash
$ du -hs node_modules/react-tipsy/*
4.0K	node_modules/react-tipsy/CHANGES
4.0K	node_modules/react-tipsy/LICENSE
4.0K	node_modules/react-tipsy/README.md
20K	node_modules/react-tipsy/dist
4.0K	node_modules/react-tipsy/package.json
```