### PR TITLE
Classname support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,16 @@ You can also use the standalone build by including `dist/react-tipsy.min.js` and
 ```
 var Tipsy = require('react-tipsy');
 
-<Tipsy content="Hello, world!" placement="bottom" trigger="hover focus touch">
+<Tipsy content="Hello, world!" placement="bottom" trigger="hover focus touch" className="my-tooltip">
     <h1>Welcome!</h1>
 </Tipsy>
 ```
 
-The `chidren` property **_must_** be a React Element. **(required)**
+The `children` property **_must_** be a React Element. **(required)**
 The `content` property can be a any mountable type but this is most likely a string. **(required)**
 The `placement` property is where to position the tooltip. Valid options are: `top`, `right`, `bottom` and `left`. Defaults to `"top"`.
 The `trigger` property is a string that determines how the tooltip is triggered. Valid options are: `click`, `hover`, `focus`, `touch` or just `manual`. You may pass multiple triggers; separate them with a space. Pass a string value of "manual" to manually trigger the tooltip. Defaults to `"hover focus touch"`.
+The `className` property is a standard space-separated list of classes to apply to the main tooltip element when it rendered. This can be used to add custom styling to a specific tooltip.
 
 ### Methods
 

--- a/src/Tipsy.js
+++ b/src/Tipsy.js
@@ -101,7 +101,7 @@ export default class Tipsy extends Component {
 
     // render tooltip
     const element = (
-      <div className={`Tipsy in ${this.props.placement}`} role="tooltip">
+      <div className={`Tipsy in ${this.props.placement} ${this.props.className}`} role="tooltip">
         <div className="Tipsy-arrow"></div>
         <div className="Tipsy-inner">{this.props.content}</div>
       </div>


### PR DESCRIPTION
As a developer integrating the tooltip library, I would like to be able to append a specific class or classes to the rendered tooltip so that I can control styling for a single tooltip without creating extraneous wrapping elements.